### PR TITLE
feat(clipboard): add text tab to navigation

### DIFF
--- a/Rememory/Models/TabItemModel.cs
+++ b/Rememory/Models/TabItemModel.cs
@@ -10,9 +10,10 @@ namespace Rememory.Models
         public static IEnumerable<TabItemModel> GetDefaultTabs() => [
                 new(NavigationTabItemType.Home, "/Clipboard/NavigationTab_Home/Text".GetLocalizedResource(), "\uE80F", "1", "/Clipboard/NavigationTab_Home/Description".GetLocalizedResource(), "\uF0E3"),
                 new(NavigationTabItemType.Fovorites, "/Clipboard/NavigationTab_Favorites/Text".GetLocalizedResource(), "\uE734", "2", "/Clipboard/NavigationTab_Favorites/Description".GetLocalizedResource()),
-                new(NavigationTabItemType.Images, "/Clipboard/NavigationTab_Images/Text".GetLocalizedResource(), "\uE8B9", "3", "/Clipboard/NavigationTab_Images/Description".GetLocalizedResource()),
-                new(NavigationTabItemType.Files, "/Clipboard/NavigationTab_Files/Text".GetLocalizedResource(), "\uE8B7", "4", "/Clipboard/NavigationTab_Files/Description".GetLocalizedResource()),
-                new(NavigationTabItemType.Links, "/Clipboard/NavigationTab_Links/Text".GetLocalizedResource(), "\uE71B", "5", "/Clipboard/NavigationTab_Links/Description".GetLocalizedResource())
+                new(NavigationTabItemType.Text, "/Clipboard/NavigationTab_Text/Text".GetLocalizedResource(), "\uE8E9", "3", "/Clipboard/NavigationTab_Text/Description".GetLocalizedResource()),
+                new(NavigationTabItemType.Images, "/Clipboard/NavigationTab_Images/Text".GetLocalizedResource(), "\uE8B9", "4", "/Clipboard/NavigationTab_Images/Description".GetLocalizedResource()),
+                new(NavigationTabItemType.Files, "/Clipboard/NavigationTab_Files/Text".GetLocalizedResource(), "\uE8B7", "5", "/Clipboard/NavigationTab_Files/Description".GetLocalizedResource()),
+                new(NavigationTabItemType.Links, "/Clipboard/NavigationTab_Links/Text".GetLocalizedResource(), "\uE71B", "6", "/Clipboard/NavigationTab_Links/Description".GetLocalizedResource())
             ];
     }
 
@@ -91,6 +92,7 @@ namespace Rememory.Models
     {
         Home,
         Fovorites,
+        Text,
         Images,
         Files,
         Links,

--- a/Rememory/Strings/en-US/Clipboard.resw
+++ b/Rememory/Strings/en-US/Clipboard.resw
@@ -240,6 +240,12 @@
   <data name="NavigationTab_Favorites.Description" xml:space="preserve">
     <value>Your favorite clips will show up here</value>
   </data>
+  <data name="NavigationTab_Text.Text" xml:space="preserve">
+    <value>Text</value>
+  </data>
+  <data name="NavigationTab_Text.Description" xml:space="preserve">
+    <value>Your copied text will show up here</value>
+  </data>
   <data name="NavigationTab_Images.Text" xml:space="preserve">
     <value>Images</value>
   </data>

--- a/Rememory/ViewModels/ClipboardRootPageViewModel.cs
+++ b/Rememory/ViewModels/ClipboardRootPageViewModel.cs
@@ -298,6 +298,7 @@ namespace Rememory.ViewModels
             {
                 NavigationTabItemType.Home => true,
                 NavigationTabItemType.Fovorites => item.IsFavorite,
+                NavigationTabItemType.Text => item.Data.ContainsKey(ClipboardFormat.Text) || item.Data.ContainsKey(ClipboardFormat.Rtf) || item.Data.ContainsKey(ClipboardFormat.Html),
                 NavigationTabItemType.Images => item.Data.ContainsKey(ClipboardFormat.Png) || item.Data.ContainsKey(ClipboardFormat.Bitmap),
                 NavigationTabItemType.Files => item.Data.ContainsKey(ClipboardFormat.Files),
                 NavigationTabItemType.Links => item.IsLink,


### PR DESCRIPTION
Add a new "Text" tab to the clipboard navigation, allowing users to view copied text clips.