### PR TITLE
Fix: Window grabbing the focus, it will interrupt the operation of some controls(such as edit box)

### DIFF
--- a/Rememory/Helper/NativeHelper.cs
+++ b/Rememory/Helper/NativeHelper.cs
@@ -56,6 +56,7 @@ namespace Rememory.Helper
 
 
         internal const int WH_KEYBOARD_LL = 13;
+        internal const int WH_MOUSE_LL = 14;
 
         internal delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
 

--- a/Rememory/Helper/NativeHelper.cs
+++ b/Rememory/Helper/NativeHelper.cs
@@ -205,6 +205,14 @@ namespace Rememory.Helper
         internal const uint WS_EX_NOACTIVATE = 0x08000000;
         internal const uint WS_EX_LAYERED = 0x00080000;
 
+        internal const int GWL_EXSTYLE = -20;
+
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
         internal const uint CS_VREDRAW = 1;
         internal const uint CS_HREDRAW = 2;
         internal const uint COLOR_BACKGROUND = 1;

--- a/Rememory/Hooks/GlobalMouseHook.cs
+++ b/Rememory/Hooks/GlobalMouseHook.cs
@@ -1,0 +1,136 @@
+using Rememory.Helper;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Windows.Graphics;
+
+namespace Rememory.Hooks
+{
+    public class GlobalMouseHook : IDisposable
+    {
+        private IntPtr _user32LibraryHandle;
+        private IntPtr _windowsMouseHookHandle;
+        private NativeHelper.HookProc _mouseHookProc;
+
+        internal event EventHandler<MouseHookEventArgs>? MouseEvent;
+
+        public GlobalMouseHook()
+        {
+            _user32LibraryHandle = IntPtr.Zero;
+            _windowsMouseHookHandle = IntPtr.Zero;
+            _mouseHookProc = LowLevelMouseProc;
+
+            _user32LibraryHandle = NativeHelper.LoadLibrary("User32");
+            if (_user32LibraryHandle == IntPtr.Zero)
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                throw new Win32Exception(errorCode, $"Failed to load library 'User32.dll'. Error {errorCode}: {new Win32Exception(Marshal.GetLastWin32Error()).Message}.");
+            }
+        }
+
+        public void AddMouseHook()
+        {
+            if (_windowsMouseHookHandle != IntPtr.Zero) return;
+            _windowsMouseHookHandle = NativeHelper.SetWindowsHookEx(NativeHelper.WH_MOUSE_LL, _mouseHookProc, _user32LibraryHandle, 0);
+            if (_windowsMouseHookHandle == IntPtr.Zero)
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                throw new Win32Exception(errorCode, $"Failed to adjust mouse hooks for '{Process.GetCurrentProcess().ProcessName}'. Error {errorCode}: {new Win32Exception(Marshal.GetLastWin32Error()).Message}.");
+            }
+        }
+
+        public void RemoveMouseHook()
+        {
+            if (_windowsMouseHookHandle != IntPtr.Zero)
+            {
+                if (!NativeHelper.UnhookWindowsHookEx(_windowsMouseHookHandle))
+                {
+                    int errorCode = Marshal.GetLastWin32Error();
+                    throw new Win32Exception(errorCode, $"Failed to remove mouse hooks for '{Process.GetCurrentProcess().ProcessName}'. Error {errorCode}: {new Win32Exception(Marshal.GetLastWin32Error()).Message}.");
+                }
+
+                _windowsMouseHookHandle = IntPtr.Zero;
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                RemoveMouseHook();
+                _mouseHookProc -= LowLevelMouseProc;
+            }
+
+            if (_user32LibraryHandle != IntPtr.Zero)
+            {
+                if (!NativeHelper.FreeLibrary(_user32LibraryHandle))
+                {
+                    int errorCode = Marshal.GetLastWin32Error();
+                    throw new Win32Exception(errorCode, $"Failed to unload library 'User32.dll'. Error {errorCode}: {new Win32Exception(Marshal.GetLastWin32Error()).Message}.");
+                }
+
+                _user32LibraryHandle = IntPtr.Zero;
+            }
+        }
+
+        ~GlobalMouseHook()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public enum MouseMessage
+        {
+            WM_LBUTTONDOWN = 0x0201,
+            WM_LBUTTONUP = 0x0202,
+            WM_RBUTTONDOWN = 0x0204,
+            WM_RBUTTONUP = 0x0205,
+            WM_MBUTTONDOWN = 0x0207,
+            WM_MBUTTONUP = 0x0208
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MSLLHOOKSTRUCT
+        {
+            public PointInt32 pt;
+            public uint mouseData;
+            public uint flags;
+            public uint time;
+            public IntPtr dwExtraInfo;
+        }
+
+        private IntPtr LowLevelMouseProc(int nCode, IntPtr wParam, IntPtr lParam)
+        {
+            if (nCode >= 0)
+            {
+                var wparamTyped = wParam.ToInt32();
+                if (Enum.IsDefined(typeof(MouseMessage), wparamTyped))
+                {
+                    var hookStruct = Marshal.PtrToStructure<MSLLHOOKSTRUCT>(lParam);
+                    var eventArgs = new MouseHookEventArgs(hookStruct.pt, (MouseMessage)wparamTyped);
+                    MouseEvent?.Invoke(this, eventArgs);
+                }
+            }
+
+            return NativeHelper.CallNextHookEx(IntPtr.Zero, nCode, wParam, lParam);
+        }
+    }
+
+    public class MouseHookEventArgs : EventArgs
+    {
+        public PointInt32 Position { get; }
+        public GlobalMouseHook.MouseMessage Message { get; }
+
+        public MouseHookEventArgs(PointInt32 position, GlobalMouseHook.MouseMessage message)
+        {
+            Position = position;
+            Message = message;
+        }
+    }
+}

--- a/Rememory/Hooks/KeyboardMonitor.cs
+++ b/Rememory/Hooks/KeyboardMonitor.cs
@@ -80,7 +80,168 @@ namespace Rememory.Hooks
                     }
                     args.Handled = true;
                 }
+                return;
             }
+
+            var clipboardWindow = App.Current.ClipboardWindow;
+            if (clipboardWindow.Visible && args.KeyboardState == GlobalKeyboardHook.KeyboardState.KeyDown)
+            {
+                if (pressedKey == (int)VirtualKey.Escape)
+                {
+                    clipboardWindow.DispatcherQueue.TryEnqueue(() =>
+                    {
+                        var rootPage = clipboardWindow.Content as Views.ClipboardRootPage;
+                        bool flyoutClosed = rootPage?.HandleEscapeKey() ?? false;
+
+                        if (!flyoutClosed)
+                        {
+                            clipboardWindow.HideWindow();
+                        }
+                    });
+                    args.Handled = true;
+                    return;
+                }
+
+                // Tab/Shift+Tab: Handle focus navigation
+                if (pressedKey == (int)VirtualKey.Tab)
+                {
+                    bool isShiftPressed = currentlyPressedKeys.Contains((int)VirtualKey.Shift);
+                    clipboardWindow.DispatcherQueue.TryEnqueue(() =>
+                    {
+                        var direction = isShiftPressed 
+                            ? Microsoft.UI.Xaml.Input.FocusNavigationDirection.Previous 
+                            : Microsoft.UI.Xaml.Input.FocusNavigationDirection.Next;
+
+                        var options = new Microsoft.UI.Xaml.Input.FindNextElementOptions()
+                        {
+                            SearchRoot = clipboardWindow.Content
+                        };
+
+                        Microsoft.UI.Xaml.Input.FocusManager.TryMoveFocus(direction, options);
+                    });
+                    args.Handled = true;
+                    return;
+                }
+
+                // Enter/Shift+Enter: Handle paste actions
+                if (pressedKey == (int)VirtualKey.Enter)
+                {
+                    clipboardWindow.DispatcherQueue.TryEnqueue(() =>
+                    {
+                        var rootPage = clipboardWindow.Content as Views.ClipboardRootPage;
+                        rootPage?.HandleEnterKey();
+                    });
+                    args.Handled = true;
+                    return;
+                }
+
+                // Arrow keys: Handle navigation
+                if (pressedKey == (int)VirtualKey.Up || 
+                    pressedKey == (int)VirtualKey.Down || 
+                    pressedKey == (int)VirtualKey.Left || 
+                    pressedKey == (int)VirtualKey.Right)
+                {
+                    clipboardWindow.DispatcherQueue.TryEnqueue(() =>
+                    {
+                        var rootPage = clipboardWindow.Content as Views.ClipboardRootPage;
+                        rootPage?.HandleArrowKeyNavigation((VirtualKey)pressedKey);
+                    });
+                    args.Handled = true;
+                    return;
+                }
+
+                // Ctrl+T: Toggle pin
+                if (currentlyPressedKeys.Count == 2 &&
+                    currentlyPressedKeys.Contains((int)VirtualKey.Control) &&
+                    currentlyPressedKeys.Contains((int)VirtualKey.T))
+                {
+                    clipboardWindow.DispatcherQueue.TryEnqueue(() =>
+                    {
+                        var viewModel = (clipboardWindow.Content as Views.ClipboardRootPage)?.ViewModel;
+                        if (viewModel?.ToggleWindowPinnedCommand.CanExecute(null) ?? false)
+                        {
+                            viewModel.ToggleWindowPinnedCommand.Execute(null);
+                        }
+                    });
+                    args.Handled = true;
+                    return;
+                }
+
+                // Ctrl+M: Toggle clipboard monitoring
+                if (currentlyPressedKeys.Count == 2 &&
+                    currentlyPressedKeys.Contains((int)VirtualKey.Control) &&
+                    currentlyPressedKeys.Contains((int)VirtualKey.M))
+                {
+                    clipboardWindow.DispatcherQueue.TryEnqueue(() =>
+                    {
+                        var viewModel = (clipboardWindow.Content as Views.ClipboardRootPage)?.ViewModel;
+                        if (viewModel?.ToggleClipboardMonitoringEnabledCommand.CanExecute(null) ?? false)
+                        {
+                            viewModel.ToggleClipboardMonitoringEnabledCommand.Execute(null);
+                        }
+                    });
+                    args.Handled = true;
+                    return;
+                }
+
+                if (!clipboardWindow.Pinned && IsInputKey(pressedKey, currentlyPressedKeys))
+                {
+                    clipboardWindow.DispatcherQueue.TryEnqueue(() => clipboardWindow.HideWindow());
+                    return;
+                }
+            }
+        }
+
+        private static bool IsInputKey(int pressedKey, List<int> currentlyPressedKeys)
+        {
+            // Ignore pure modifier keys
+            if (pressedKey == (int)VirtualKey.Control ||
+                pressedKey == (int)VirtualKey.LeftControl ||
+                pressedKey == (int)VirtualKey.RightControl ||
+                pressedKey == (int)VirtualKey.Shift ||
+                pressedKey == (int)VirtualKey.LeftShift ||
+                pressedKey == (int)VirtualKey.RightShift ||
+                pressedKey == (int)VirtualKey.Menu ||
+                pressedKey == (int)VirtualKey.LeftMenu ||
+                pressedKey == (int)VirtualKey.RightMenu ||
+                pressedKey == (int)VirtualKey.LeftWindows ||
+                pressedKey == (int)VirtualKey.RightWindows)
+            {
+                return false;
+            }
+
+            // Ignore if any modifier is pressed (could be a shortcut)
+            if (currentlyPressedKeys.Contains((int)VirtualKey.Control) ||
+                currentlyPressedKeys.Contains((int)VirtualKey.Menu) ||
+                currentlyPressedKeys.Contains((int)VirtualKey.LeftWindows))
+            {
+                return false;
+            }
+
+            // Ignore special keys that don't represent input
+            if (pressedKey == (int)VirtualKey.CapitalLock ||
+                pressedKey == (int)VirtualKey.NumberKeyLock ||
+                pressedKey == (int)VirtualKey.Scroll)
+            {
+                return false;
+            }
+
+            // Navigation keys should NOT trigger window hide
+            if (pressedKey == (int)VirtualKey.Tab ||
+                pressedKey == (int)VirtualKey.Enter ||
+                pressedKey == (int)VirtualKey.Up ||
+                pressedKey == (int)VirtualKey.Down ||
+                pressedKey == (int)VirtualKey.Left ||
+                pressedKey == (int)VirtualKey.Right ||
+                pressedKey == (int)VirtualKey.Home ||
+                pressedKey == (int)VirtualKey.End ||
+                pressedKey == (int)VirtualKey.PageUp ||
+                pressedKey == (int)VirtualKey.PageDown)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private void AddModifierKeys(List<int> currentlyPressedKeys)

--- a/Rememory/Hooks/KeyboardMonitor.cs
+++ b/Rememory/Hooks/KeyboardMonitor.cs
@@ -118,6 +118,14 @@ namespace Rememory.Hooks
                         };
 
                         Microsoft.UI.Xaml.Input.FocusManager.TryMoveFocus(direction, options);
+
+                        var focusedElement = Microsoft.UI.Xaml.Input.FocusManager.GetFocusedElement() as Microsoft.UI.Xaml.DependencyObject;
+                        bool acceptsTextInput = focusedElement is Microsoft.UI.Xaml.Controls.TextBox
+                            || focusedElement is Microsoft.UI.Xaml.Controls.AutoSuggestBox
+                            || focusedElement is Microsoft.UI.Xaml.Controls.PasswordBox
+                            || focusedElement is Microsoft.UI.Xaml.Controls.RichEditBox;
+
+                        clipboardWindow.SetAllowKeyboardInput(acceptsTextInput);
                     });
                     args.Handled = true;
                     return;
@@ -184,11 +192,8 @@ namespace Rememory.Hooks
                     return;
                 }
 
-                if (!clipboardWindow.Pinned && IsInputKey(pressedKey, currentlyPressedKeys))
-                {
-                    clipboardWindow.DispatcherQueue.TryEnqueue(() => clipboardWindow.HideWindow());
-                    return;
-                }
+                // Don't intercept other keys, let them pass through. This allows text input controls like SearchBox to work 
+                // The window will still hide on mouse click outside or press escape key
             }
         }
 

--- a/Rememory/Views/ClipboardRootPage.xaml
+++ b/Rememory/Views/ClipboardRootPage.xaml
@@ -14,8 +14,7 @@
       xmlns:selector="using:Rememory.Views.Controls.Selector"
       x:Name="RootPage"
       DataContext="{x:Bind ViewModel}"
-      SizeChanged="ClipboardRootPage_SizeChanged"
-      KeyDown="RootPage_KeyDown">
+      SizeChanged="ClipboardRootPage_SizeChanged">
     <Page.Resources>
         <tkconverters:BoolToVisibilityConverter x:Key="InvertedBoolToVisibilityConverter"
                                                 TrueValue="Collapsed"

--- a/Rememory/Views/ClipboardRootPage.xaml
+++ b/Rememory/Views/ClipboardRootPage.xaml
@@ -948,6 +948,8 @@
                                     VerticalAlignment="Center"
                                     IsEnabled="{x:Bind ViewModel.IsSearchEnabled, Mode=OneWay}"
                                     Text="{x:Bind ViewModel.SearchString, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                    GotFocus="SearchBox_GotFocus"
+                                    LostFocus="SearchBox_LostFocus"
                                     KeyDown="SearchBox_KeyDown" />
 
                     <Button x:Name="FilterButton"

--- a/Rememory/Views/ClipboardRootPage.xaml.cs
+++ b/Rememory/Views/ClipboardRootPage.xaml.cs
@@ -203,14 +203,6 @@ namespace Rememory.Views
             ClipsListView.ItemTemplate = ViewModel.SettingsContext.IsCompactViewEnabled ? _compactClipLayoutTemplate : _clipLayoutTemplate;
         }
 
-        private void RootPage_KeyDown(object sender, KeyRoutedEventArgs e)
-        {
-            if (e.Key == VirtualKey.Escape)
-            {
-                _window.HideWindow();
-            }
-        }
-
         private void SetFocusOnFirstClipInList()
         {
             var firstClipContainer = ClipsListView.ContainerFromIndex(0) as UIElement;
@@ -503,6 +495,91 @@ namespace Rememory.Views
                     OpenPreviewFlyout((ClipModel)clipItem.Content);
                     break;
             }
+        }
+
+        public bool HandleArrowKeyNavigation(VirtualKey key)
+        {
+            var direction = key switch
+            {
+                VirtualKey.Up => Microsoft.UI.Xaml.Input.FocusNavigationDirection.Up,
+                VirtualKey.Down => Microsoft.UI.Xaml.Input.FocusNavigationDirection.Down,
+                VirtualKey.Left => Microsoft.UI.Xaml.Input.FocusNavigationDirection.Left,
+                VirtualKey.Right => Microsoft.UI.Xaml.Input.FocusNavigationDirection.Right,
+                _ => Microsoft.UI.Xaml.Input.FocusNavigationDirection.None
+            };
+
+            if (direction == Microsoft.UI.Xaml.Input.FocusNavigationDirection.None)
+            {
+                return false;
+            }
+
+            var focusedElement = Microsoft.UI.Xaml.Input.FocusManager.GetFocusedElement(XamlRoot) as UIElement;
+            if (focusedElement is ListViewItem item && ItemsControl.ItemsControlFromItemContainer(item) == ClipsListView)
+            {
+                if (key == VirtualKey.Up && item.Content == ClipsListView.Items.FirstOrDefault())
+                {
+                    SearchBox.Focus(FocusState.Programmatic);
+                    return true;
+                }
+
+                if (key == VirtualKey.Left)
+                {
+                    var selectedItemContainer = NavigationTabView.ContainerFromMenuItem(NavigationTabView.SelectedItem) as UIElement;
+                    selectedItemContainer?.Focus(FocusState.Programmatic);
+                    return true;
+                }
+            }
+
+            var options = new Microsoft.UI.Xaml.Input.FindNextElementOptions()
+            {
+                SearchRoot = this
+            };
+
+            return Microsoft.UI.Xaml.Input.FocusManager.TryMoveFocus(direction, options);
+        }
+
+        public bool HandleEnterKey()
+        {
+            var focusedElement = Microsoft.UI.Xaml.Input.FocusManager.GetFocusedElement(XamlRoot);
+
+            if (focusedElement is UIElement uiElement)
+            {
+                var peer = Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer.FromElement(uiElement);
+
+                if (peer is not null)
+                {
+                    var selectionItemProvider = peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.SelectionItem) as Microsoft.UI.Xaml.Automation.Provider.ISelectionItemProvider;
+
+                    if (selectionItemProvider is not null && !selectionItemProvider.IsSelected)
+                    {
+                        selectionItemProvider.Select();
+                        return true;
+                    }
+
+                    var invokeProvider = peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke) as Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider;
+
+                    if (invokeProvider is not null)
+                    {
+                        invokeProvider.Invoke();
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public bool HandleEscapeKey()
+        {
+            var openPopups = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetOpenPopupsForXamlRoot(XamlRoot);
+
+            if (openPopups is not null && openPopups.Count > 0)
+            {
+                openPopups[openPopups.Count - 1].IsOpen = false;
+                return true;
+            }
+
+            return false;
         }
 
         private void ClipsListView_PreviewKeyUp(object sender, KeyRoutedEventArgs e)

--- a/Rememory/Views/ClipboardRootPage.xaml.cs
+++ b/Rememory/Views/ClipboardRootPage.xaml.cs
@@ -754,5 +754,16 @@ namespace Rememory.Views
                 ViewModel.EraseClipsOnSelectedTabCommand.Execute(null);
             }
         }
+
+        private void SearchBox_GotFocus(object sender, RoutedEventArgs e)
+        {
+            App.Current.ClipboardWindow?.SetAllowKeyboardInput(true);
+            SearchBox.Focus(FocusState.Programmatic);
+        }
+
+        private void SearchBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            App.Current.ClipboardWindow?.SetAllowKeyboardInput(false);
+        }
     }
 }

--- a/Rememory/Views/ClipboardWindow.cs
+++ b/Rememory/Views/ClipboardWindow.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Rememory.Helper;
 using Rememory.Helper.WindowBackdrop;
+using Rememory.Hooks;
 using Rememory.Models;
 using Rememory.Views.Settings;
 using System;
@@ -16,6 +17,7 @@ using Windows.System;
 using WinRT.Interop;
 using WinUIEx;
 using WinUIEx.Messaging;
+using Microsoft.UI.Dispatching;
 
 namespace Rememory.Views
 {
@@ -31,6 +33,7 @@ namespace Rememory.Views
         public readonly bool IsRoundedCornerSupported;
         private readonly InputNonClientPointerSource _inputNonClientPointerSource;
         private readonly WindowMessageMonitor _messageMonitor;
+        private readonly GlobalMouseHook _globalMouseHook = new();
 
         private bool _pinned = false;
         /// <summary>
@@ -90,6 +93,9 @@ namespace Rememory.Views
             _inputNonClientPointerSource = InputNonClientPointerSource.GetForWindowId(AppWindow.Id);
             _inputNonClientPointerSource.ExitedMoveSize += InputNonClientPointerSource_ExitedMoveSize;
 
+            // Set up mouse hook to detect clicks outside the window
+            _globalMouseHook.MouseEvent += GlobalMouseHook_MouseEvent;
+
             Activated += Window_Activated;
             AppWindow.Closing += Window_Closing;
             Closed += Window_Closed;
@@ -105,10 +111,11 @@ namespace Rememory.Views
             }
             MoveToStartPosition(position);
             Showing?.Invoke(this, EventArgs.Empty);
-            AppWindow.Show();
+            AppWindow.Show(activateWindow: false);
             IsAlwaysOnTop = true;
-            KeyboardHelper.MultiKeyAction([(VirtualKey)0x0E], KeyboardHelper.KeyAction.DownUp);   // To fix problem with foreground window
-            this.SetForegroundWindow();
+
+            _globalMouseHook.AddMouseHook();
+
             return true;
         }
 
@@ -118,6 +125,9 @@ namespace Rememory.Views
             {
                 return false;
             }
+
+            _globalMouseHook.RemoveMouseHook();
+
             Hiding?.Invoke(this, EventArgs.Empty);
             AppWindow.Hide();
             return true;
@@ -214,6 +224,32 @@ namespace Rememory.Views
             }
         }
 
+        private void GlobalMouseHook_MouseEvent(object? sender, MouseHookEventArgs e)
+        {
+            // Only handle left button down to detect clicks
+            if (e.Message != GlobalMouseHook.MouseMessage.WM_LBUTTONDOWN && e.Message != GlobalMouseHook.MouseMessage.WM_RBUTTONDOWN)
+            {
+                return;
+            }
+
+            if (!Visible || Pinned)
+            {
+                return;
+            }
+
+            var windowBounds = new RectInt32(AppWindow.Position.X, AppWindow.Position.Y, AppWindow.Size.Width, AppWindow.Size.Height);
+
+            if (!IsPointInRect(e.Position, windowBounds))
+            {
+                DispatcherQueue.TryEnqueue(() => HideWindow());
+            }
+        }
+
+        private bool IsPointInRect(PointInt32 point, RectInt32 rect)
+        {
+            return point.X >= rect.X && point.X < rect.X + rect.Width && point.Y >= rect.Y && point.Y < rect.Y + rect.Height;
+        }
+
         private void Window_Activated(object sender, WindowActivatedEventArgs args)
         {
             if (!Pinned && args.WindowActivationState == WindowActivationState.Deactivated)
@@ -231,6 +267,8 @@ namespace Rememory.Views
         private void Window_Closed(object sender, WindowEventArgs args)
         {
             SettingsWindow.CloseSettingsWindow();
+            _globalMouseHook.MouseEvent -= GlobalMouseHook_MouseEvent;
+            _globalMouseHook.Dispose();
             Activated -= Window_Activated;
             AppWindow.Closing -= Window_Closing;
             Closed -= Window_Closed;

--- a/Rememory/Views/ClipboardWindow.cs
+++ b/Rememory/Views/ClipboardWindow.cs
@@ -113,6 +113,7 @@ namespace Rememory.Views
             Showing?.Invoke(this, EventArgs.Empty);
             AppWindow.Show(activateWindow: false);
             IsAlwaysOnTop = true;
+            KeyboardHelper.MultiKeyAction([(VirtualKey)0x0E], KeyboardHelper.KeyAction.DownUp);
 
             _globalMouseHook.AddMouseHook();
 

--- a/Rememory/Views/ClipboardWindow.cs
+++ b/Rememory/Views/ClipboardWindow.cs
@@ -80,6 +80,7 @@ namespace Rememory.Views
             AppWindow.SetTitleBarIcon(AppContext.BaseDirectory + "Assets\\WindowIcon.ico");
 
             this.SetWindowStyle(WindowStyle.Popup);
+            this.SetExtendedWindowStyle(ExtendedWindowStyle.NoActivate);
             int cornerPreference = (int)NativeHelper.DWM_WINDOW_CORNER_PREFERENCE.DWMWCP_ROUND;
             nint dwmResult = NativeHelper.DwmSetWindowAttribute(this.GetWindowHandle(), NativeHelper.DWMWA_WINDOW_CORNER_PREFERENCE, ref cornerPreference, sizeof(int));
             IsRoundedCornerSupported = dwmResult == 0;

--- a/Rememory/Views/ClipboardWindow.cs
+++ b/Rememory/Views/ClipboardWindow.cs
@@ -595,6 +595,29 @@ namespace Rememory.Views
                 AppWindow.MoveAndResize(new(x, y, independedWidth, independedHeight));
             }
         }
+
+        public void SetAllowKeyboardInput(bool allow)
+        {
+            var exStyle = NativeHelper.GetWindowLongPtr(Handle, NativeHelper.GWL_EXSTYLE);
+
+            if (allow)
+            {
+                // Remove NoActivate to allow keyboard input
+                exStyle = new IntPtr(exStyle.ToInt64() & ~NativeHelper.WS_EX_NOACTIVATE);
+            }
+            else
+            {
+                // Restore NoActivate to prevent focus stealing
+                exStyle = new IntPtr(exStyle.ToInt64() | NativeHelper.WS_EX_NOACTIVATE);
+            }
+
+            NativeHelper.SetWindowLongPtr(Handle, NativeHelper.GWL_EXSTYLE, exStyle);
+
+            if (allow)
+            {
+                this.SetForegroundWindow();
+            }
+        }
     }
 
     public enum ClipboardWindowPosition


### PR DESCRIPTION
### Description

Previously, when we opened the Rememory window with shortcut keys, it would steal the focus of the current application, thus interrupting some operations (such as the editing box being entered). Now we have fixed this issue.

Solved #111

### Supplement

The principle of achieving this goal is actually very simple. We can avoid the pop-up window from grabbing the focus by setting `WS_EX_NOACTIVATE`.

But the difficulty of the problem is that if the Rememory window has no focus, we need extra code to control the hiding of the window. In the past, we could hide the window naturally when the window lost focus. Now we have to set an extra mouse hook, which will be added when the window opens, and we can hide the window when it is detected that the click event does not occur in the Rememory window.

At the same time, this scheme will not bring significant performance overhead. Because when the window is hidden, we have removed the mouse hook, and this hook will be added again until the next window is opened.

### Screenshots

<img width="693" height="548" alt="image" src="https://github.com/user-attachments/assets/620de51f-dee3-4650-8fcd-42f752ede0d3" />

#### Demonstration in explorer

<img width="398" height="320" alt="PixPin_2026-05-04_12-41-19" src="https://github.com/user-attachments/assets/76fdc443-e5a9-46e6-825a-37b41f566f9c" />
